### PR TITLE
Simple state machine and startup function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Thumbs.db
 *.VC.opendb
 *.suo
 /packages/
+/TestClient/*.user

--- a/TestClient/Net/NetworkManager.cs
+++ b/TestClient/Net/NetworkManager.cs
@@ -592,6 +592,7 @@ namespace TestClient.Net
 
 			this.connection = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
 			this.connection.Bind(this.localAddr);
+			this.connection.EnableConnectionResetWrapper(false);
 			this.shouldBeRunning = true;
 
 			DoReceive();

--- a/TestClient/Net/WinSock.cs
+++ b/TestClient/Net/WinSock.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Text;
+
+namespace TestClient.Net
+{
+	internal static class WinSock
+	{
+		/// <summary>
+		/// From winsock2.h
+		/// https://docs.microsoft.com/en-us/windows/win32/winsock/winsock-ioctls
+		/// Winsock Socket input/output controls (IOCTLs)
+		/// </summary>
+		[Flags]
+		internal enum IOC_Direction : uint
+		{
+			IOCPARM_MASK = 0x7f,
+			IOC_VOID = 0x20000000,
+			IOC_OUT = 0x40000000,
+			IOC_IN = 0x80000000,
+			IOC_INOUT = IOC_IN | IOC_OUT
+		}
+		/// <summary>
+		/// From winsock2.h
+		/// https://docs.microsoft.com/en-us/windows/win32/winsock/winsock-ioctls
+		/// Winsock Socket input/output controls (IOCTLs)
+		/// </summary>
+		[Flags]
+		internal enum IOC_Parameter : uint
+		{
+			IOC_UNIX = 0x00000000,
+			IOC_WS2 = 0x08000000,
+			IOC_PROTOCOL = 0x10000000,
+			IOC_VENDOR = 0x18000000,
+			SIO_UDP_CONNRESET = IOC_Direction.IOC_IN | IOC_VENDOR | 12
+		}
+
+		/// <summary>
+		/// From winsock2.h
+		/// https://docs.microsoft.com/en-us/windows/win32/winsock/winsock-ioctls
+		/// Winsock Socket input/output controls (IOCTLs)
+		/// </summary>
+		private const int SIO_UDP_CONNRESET_INT = unchecked((int)IOC_Parameter.SIO_UDP_CONNRESET);//-1744830452;
+
+		/// <summary>
+		/// https://docs.microsoft.com/en-us/windows/win32/winsock/winsock-ioctls#sio_udp_connreset-opcode-setting-i-t3
+		/// Enabled wrapper provides connection reset notifications in the form of a SocketException.
+		/// Enable to throw an exception when trying to send UDP to a non-listening remote socket.
+		/// Disable to ignore "The connection was reset by the remote peer." type errors.
+		/// </summary>
+		/// <param name="_enabled"></param>
+		public static bool EnableConnectionResetWrapper(this Socket sock, bool _enabled)
+		{
+			byte[] inValue = new byte[] { _enabled ? (byte)1 : (byte)0 };
+			byte[] outValue = new byte[] { 0 };
+			try
+			{
+				int i = sock.IOControl(SIO_UDP_CONNRESET_INT, inValue, outValue);
+				return i == 0;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+	}
+}

--- a/TestClient/Program.cs
+++ b/TestClient/Program.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
-
+using System.Linq;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Scripting.Utils;
 
 // https://github.com/migueldeicaza/gui.cs/
 // https://blog.terribledev.io/Parsing-cli-arguments-in-dotnet-core-Console-App/
@@ -44,6 +45,7 @@ namespace TestClient
 			commandManager = new CommandManager();
 			displayManager = new DisplayManager();
 			networkManager = new NetworkManager();
+
 			scriptManager = new ScriptManager("script", config["script:python_lib"]);
 			scriptManager.SetDisplayManager(displayManager);
 

--- a/TestClient/Program.cs
+++ b/TestClient/Program.cs
@@ -59,6 +59,16 @@ namespace TestClient
 
 			MessageParser.Initialize("messages.xml");
 
+			commandManager.CreateCommand("start", () =>
+			{
+				scriptManager.CallApiStartup();
+				return 0;
+			});
+
+			scriptManager.SetNetworkManager(networkManager);
+			scriptManager.ScriptThreadReady.WaitOne();
+			scriptManager.CallApiStartup();
+
 			while (true)
 			{
 				//displayManager.Clear();

--- a/TestClient/Program.cs
+++ b/TestClient/Program.cs
@@ -61,8 +61,8 @@ namespace TestClient
 
 			while (true)
 			{
-				displayManager.Clear();
-				displayManager.Refresh();
+				//displayManager.Clear();
+				//displayManager.Refresh();
 				//displayManager.Write(0, 0, "AC Test Client");
 
 				//displayManager.Write(-15, 0, networkManager == null ? "Disconnected" : networkManager.World);

--- a/TestClient/Scripts/IScriptMessageHandler.cs
+++ b/TestClient/Scripts/IScriptMessageHandler.cs
@@ -12,4 +12,11 @@ namespace TestClient.Scripts
 		//void HandleMessage(uint type, MessageDelegate handler);
 		//void HandleMessage(uint type, uint eventCode, MessageDelegate handler);
 	}
+
+	[Documentation("Interface for startup")]
+	public interface IScriptStartupHandler
+	{
+		Action HandleStartup { get; }
+		Action<uint> HandleStartupEvent { get; }
+	}
 }

--- a/TestClient/TestClient.csproj
+++ b/TestClient/TestClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.2</LangVersion>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -13,13 +13,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IronPython" Version="2.7.8.1" />
+    <PackageReference Include="IronPython" Version="2.7.10" />
     <PackageReference Include="microsoft.extensions.commandlineutils" Version="1.1.1" />
-    <PackageReference Include="microsoft.extensions.configuration" Version="2.1.1" />
-    <PackageReference Include="microsoft.extensions.configuration.json" Version="2.1.1" />
-    <PackageReference Include="system.buffers" Version="4.5.0" />
-    <PackageReference Include="system.memory" Version="4.5.1" />
-    <PackageReference Include="Terminal.Gui" Version="0.16.0" />
+    <PackageReference Include="microsoft.extensions.configuration" Version="3.1.6" />
+    <PackageReference Include="microsoft.extensions.configuration.json" Version="3.1.6" />
+    <PackageReference Include="system.buffers" Version="4.5.1" />
+    <PackageReference Include="system.memory" Version="4.5.4" />
+    <PackageReference Include="Terminal.Gui" Version="0.81.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TestClient/TestClient.csproj
+++ b/TestClient/TestClient.csproj
@@ -34,4 +34,8 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="script\api\network.py" />
+  </ItemGroup>
+
 </Project>

--- a/TestClient/Util/Exceptions.cs
+++ b/TestClient/Util/Exceptions.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Scripting.Hosting;
+using System;
+using TestClient.Scripts;
+
+namespace TestClient.Util
+{
+	internal static class Exceptions
+	{
+		public static void PythonException(this Exception ex, uint? messageType = null)
+		{
+			ExceptionOperations eo = ScriptManager.GetEngine().GetService<ExceptionOperations>();
+			string error = eo.FormatException(ex);
+			if (messageType != null)
+			{
+				WriteChat($"Error handling message {messageType:X4} : {error}");
+			}
+			else
+			{
+				WriteChat(error);
+			}
+		}
+		public static void WriteChat(string chat)
+		{
+			Console.WriteLine(chat);
+		}
+	}
+}

--- a/TestClient/Ux/CommandManager.cs
+++ b/TestClient/Ux/CommandManager.cs
@@ -6,6 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.CommandLineUtils;
+using Microsoft.Scripting.Hosting;
+using TestClient.Scripts;
 
 namespace TestClient.Ux
 {
@@ -16,6 +18,7 @@ namespace TestClient.Ux
 		private const string HelpOption = "-? | -h | --help";
 
 		private CommandLineApplication parser;
+
 		//private Thread inputThread;
 		//private bool running;
 
@@ -104,6 +107,9 @@ namespace TestClient.Ux
 				}
 				catch (Exception ex)
 				{
+					ExceptionOperations eo = ScriptManager.GetEngine().GetService<ExceptionOperations>();
+					string error = eo.FormatException(ex);
+					Console.WriteLine(error);
 				}
 
 				readResult.Dispose();
@@ -169,6 +175,7 @@ namespace TestClient.Ux
 					parser.ShowHelp();
 					return 0;
 				});
+
 			// parser.Command("help", config =>
 			// 	{
 			// 		config.OnExecute(() =>
@@ -256,6 +263,8 @@ namespace TestClient.Ux
 						ScriptReload();
 					return 0;
 				});
+
+
 
 			// cmd.Command("exec", config =>
 			// 	{

--- a/TestClient/Ux/CommandManager.cs
+++ b/TestClient/Ux/CommandManager.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Scripting.Hosting;
 using TestClient.Scripts;
+using TestClient.Util;
 
 namespace TestClient.Ux
 {
@@ -33,8 +34,6 @@ namespace TestClient.Ux
 			Instance = this;
 
 			Init();
-			//inputThread = new Thread(InputThreadStart);
-			//inputThread.Start();
 		}
 
 		private static string[] ToStrings(string commandLine)
@@ -97,7 +96,6 @@ namespace TestClient.Ux
 
 			if (readResult.IsCompleted)
 			{
-				//string commands = Console.ReadLine();
 				string commands = readResult.Result;
 
 				try
@@ -107,9 +105,7 @@ namespace TestClient.Ux
 				}
 				catch (Exception ex)
 				{
-					ExceptionOperations eo = ScriptManager.GetEngine().GetService<ExceptionOperations>();
-					string error = eo.FormatException(ex);
-					Console.WriteLine(error);
+					ex.PythonException();
 				}
 
 				readResult.Dispose();
@@ -175,16 +171,6 @@ namespace TestClient.Ux
 					parser.ShowHelp();
 					return 0;
 				});
-
-			// parser.Command("help", config =>
-			// 	{
-			// 		config.OnExecute(() =>
-			// 		{
-			// 			parser.ShowHelp();
-			// 			return 0;
-			// 		});
-			// 	});
-
 			CommandLineApplication cmd;
 
 			// network

--- a/TestClient/config.json
+++ b/TestClient/config.json
@@ -1,5 +1,5 @@
 {
     "script" : {
-        "python_lib" : "c:\\Development\\Python\\2.7\\Lib"
+        "python_lib" : "C:\\Python27\\Lib"
     }
 }

--- a/TestClient/config.json
+++ b/TestClient/config.json
@@ -1,5 +1,6 @@
 {
-    "script" : {
-        "python_lib" : "C:\\Python27\\Lib"
-    }
+  "script": {
+    // for reading standard API
+    "python_lib": "C:\\Python27-64\\Lib"
+  }
 }

--- a/TestClient/script/api/__init__.py
+++ b/TestClient/script/api/__init__.py
@@ -10,7 +10,7 @@ from .messages import *
 from .commands import *
 from .actions import *
 
+from .network import *
 from .display import *
 from .world import *
 from .character import *
-

--- a/TestClient/script/api/network.py
+++ b/TestClient/script/api/network.py
@@ -1,0 +1,16 @@
+﻿from . import _network_manager
+
+
+__all__ = ["Configure", "Connect"]
+
+def Configure(port=12345):
+	_network_manager.Configure(port)
+
+def Configure():
+	_network_manager.Configure()
+
+def Connect(address, port, username, password):
+	_network_manager.Connect(address, port, username, password)
+
+
+

--- a/TestClient/script/test.py
+++ b/TestClient/script/test.py
@@ -4,8 +4,9 @@ from __future__ import print_function
 import api
 from api.commands import *
 from api.messages import *
-
+from api.network import *
 from api.display import ChatPane, enablePane
+from api.character import *
 
 chat = ChatPane()
 enablePane(chat)
@@ -17,18 +18,42 @@ def globalChatMessage(msg):
 
 HandleMessage(0xf7de, globalChatMessage)
 
-#def createObject(msg):
-#	#print("Create Object", msg.Value[int]("object"))
-#	phys = msg.child("physics")
-#	flags = phys.flags
-#	if flags & 0x00030000:
-#		print(msg.child("game").name)
 
-#def characterInfo(msg):
-#	print("Character Info")
-#	#vecs = msg.child("vectors")
 
-#HandleMessage(0xf745, createObject)
 
-#HandleMessageEvent(0xf7b0, 0x0013, characterInfo)
+def createObject(msg):
+	#print("Create Object", msg.Value[int]("object"))
+	phys = msg.child("physics")
+	flags = phys.flags
+	if flags & 0x00030000:
+		print(msg.child("game").name)
+
+def characterInfo(msg):
+	print("Character Info")
+	#vecs = msg.child("vectors")
+
+HandleMessage(0xf745, createObject)
+
+HandleMessageEvent(0xf7b0, 0x0013, characterInfo)
+
+#called explicitly on program startup, by the script state machine, and when start command is used
+def Startup():
+	#print("Startup")
+	Configure()
+	Connect("127.0.0.1", 9000, "fart", "vSVZ3tLwSyFR7ZUp")
+	#Login(0)
+
+class TestMachine(object):
+	def __init__(self):
+		self.numloops = 0
+	def __call__(self):
+		self.numloops = self.numloops + 1
+		#print(self.numloops);
+		#if (self.numloops % 10 == 0):
+		#	Startup();
+
+
+#state machine instance called explicitly every script thread itteration
+Test = TestMachine()
+	
 


### PR DESCRIPTION
- Unfortunately IronPython has no windows curses support, because of the way it marshals objects.
- a couple possible display options might be to start implementing the unfinished display bridge via C# and use an existing nuget curses solution or upgrade to PythonNet.  I'm almost positive PythonNet can work with the Python curses extension . 
- Fixed a race condition between script system startup and the main thread.
- Fixed the display from python being clobbered by the main thread.